### PR TITLE
implement OnPublishSend callback

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,6 +14,7 @@ The MQTT Message Log is a very useful HiveMQ Plugin for debugging and developmen
 * A client subscribes to a topic
 * A client unsubscribes from a topic
 * A client disconnects from HiveMQ
+* HiveMQ send a message to a client
 
 
 == How to use the plugin

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,11 @@
             <name>Georg Held</name>
             <organization>dc-square GmbH</organization>
         </developer>
+        <developer>
+            <name>Max Marche</name>
+            <organization>tarent solutions GmbH</organization>
+            <email>m.marche@tarent.de</email>
+        </developer>
     </developers>
 
     <dependencies>

--- a/src/main/java/com/hivemq/plugin/mqttmessage/callbacks/PublishSend.java
+++ b/src/main/java/com/hivemq/plugin/mqttmessage/callbacks/PublishSend.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 dc-square GmbH
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.hivemq.plugin.mqttmessage.callbacks;
+
+import com.google.common.base.Charsets;
+import com.hivemq.spi.callback.events.OnPublishSend;
+import com.hivemq.spi.message.PUBLISH;
+import com.hivemq.spi.security.ClientData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Max Marche
+ */
+public class PublishSend implements OnPublishSend {
+    private static final Logger log = LoggerFactory.getLogger(PublishSend.class);
+
+    @Override
+    public void onPublishSend(PUBLISH publish, ClientData clientData) {
+
+        final String clientID = clientData.getClientId();
+        final String topic = publish.getTopic();
+        final String payload = new String(publish.getPayload(), Charsets.UTF_8);
+
+        log.info("Sent a message to clientId \"{}\" on topic \"{}\":\"{}\" (QoS: {}, retained: {})",
+                clientID, topic, payload, publish.getQoS().getQosNumber(), publish.isRetain());
+    }
+}

--- a/src/main/java/com/hivemq/plugin/mqttmessage/plugin/MqttMessageLog.java
+++ b/src/main/java/com/hivemq/plugin/mqttmessage/plugin/MqttMessageLog.java
@@ -23,6 +23,7 @@ import javax.annotation.PostConstruct;
 
 /**
  * @author Florian Limpöck
+ * @author Max Marche
  */
 public class MqttMessageLog extends PluginEntryPoint {
 
@@ -35,5 +36,6 @@ public class MqttMessageLog extends PluginEntryPoint {
         getCallbackRegistry().addCallback(new UnsubscribeReceived());
         getCallbackRegistry().addCallback(new ClientDisconnect());
         getCallbackRegistry().addCallback(new PublishReceived());
+        getCallbackRegistry().addCallback(new PublishSend());
     }
 }


### PR DESCRIPTION
The mqtt-message-log plugin implements all "com.hivemq.spi.callback.events.*" up to OnPublishSend. In this case implemented callback is based on "com.hivemq.spi.callback.events.OnPublishReceivedCallback".